### PR TITLE
fix: return None on undefined tool inputs to prevent eval crashes

### DIFF
--- a/app/tools.py
+++ b/app/tools.py
@@ -2,7 +2,9 @@
 Arithmetic tools for the ConvFinQA financial question-answering agent.
 
 Each tool is a plain function registered on the Agent. All tools log their
-inputs and result at DEBUG level.
+inputs and result at DEBUG level. Invalid inputs that would normally raise an
+exception are caught, logged at WARNING level, and return None so the agent
+can handle them gracefully without crashing the evaluation.
 """
 
 from loguru import logger
@@ -53,7 +55,7 @@ def multiply(multiplicand: float, multiplier: float) -> float:
     return result
 
 
-def divide(numerator: float, denominator: float) -> float:
+def divide(numerator: float, denominator: float) -> float | None:
     """Divide numerator by denominator (numerator / denominator).
 
     Args:
@@ -61,19 +63,18 @@ def divide(numerator: float, denominator: float) -> float:
         denominator: The value to divide by.
 
     Returns:
-        The quotient of numerator divided by denominator.
-
-    Raises:
-        ValueError: If denominator is zero.
+        The quotient of numerator divided by denominator, or None if
+        denominator is zero.
     """
     if denominator == 0:
-        raise ValueError("Cannot divide by zero.")
+        logger.warning(f"divide({numerator}, {denominator}): denominator is zero; returning None.")
+        return None
     result = numerator / denominator
     logger.debug(f"divide({numerator}, {denominator}) = {result}")
     return result
 
 
-def percentage_change(base_value: float, new_value: float) -> float:
+def percentage_change(base_value: float, new_value: float) -> float | None:
     """Calculate the percentage change from base_value to new_value.
 
     Returns a positive number for an increase and a negative number for a
@@ -84,13 +85,14 @@ def percentage_change(base_value: float, new_value: float) -> float:
         new_value: The new value to compare against the base.
 
     Returns:
-        The percentage change as a float (e.g. 50.0 for a 50% increase).
-
-    Raises:
-        ValueError: If base_value is zero.
+        The percentage change as a float (e.g. 50.0 for a 50% increase),
+        or None if base_value is zero.
     """
     if base_value == 0:
-        raise ValueError("Cannot calculate percentage change with a base_value of zero.")
+        logger.warning(
+            f"percentage_change(base_value={base_value}, new_value={new_value}): base_value is zero; returning None."
+        )
+        return None
     result = ((new_value - base_value) / base_value) * 100
     logger.debug(f"percentage_change(base_value={base_value}, new_value={new_value}) = {result}")
     return result
@@ -111,19 +113,34 @@ def greater(first_value: float, second_value: float) -> float:
     return result
 
 
-def exp(base: float, exponent: float) -> float:
+def exp(base: float, exponent: float) -> float | None:
     """Raise base to the given exponent (base ** exponent).
 
     Useful for compound growth calculations, e.g. exp(1.05, 3) for 3 years
     of 5% annual growth.
+
+    Negative bases with fractional exponents produce complex numbers in
+    mathematics but are undefined for real-valued arithmetic; this function
+    returns None in that case. A base of zero with a negative exponent is
+    also undefined and returns None.
 
     Args:
         base: The base value.
         exponent: The power to raise the base to.
 
     Returns:
-        base raised to the exponent.
+        base raised to the exponent, or None if the combination is undefined
+        for real-valued arithmetic.
     """
-    result = base**exponent
+    try:
+        result = base**exponent
+    except (ValueError, ZeroDivisionError) as e:
+        logger.warning(
+            f"exp(base={base}, exponent={exponent}): undefined for real-valued arithmetic ({e}); returning None."
+        )
+        return None
+    if isinstance(result, complex):
+        logger.warning(f"exp(base={base}, exponent={exponent}): result is complex ({result}); returning None.")
+        return None
     logger.debug(f"exp({base}, {exponent}) = {result}")
     return result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -94,14 +94,13 @@ class TestDivide:
         """
         assert divide(10.0, 4.0) == pytest.approx(2.5)
 
-    def test_divide_by_zero_raises_value_error(self) -> None:
+    def test_divide_by_zero_returns_none(self) -> None:
         """
         GIVEN a non-zero numerator and a zero denominator,
         WHEN divide is called,
-        THEN a ValueError is raised.
+        THEN None is returned.
         """
-        with pytest.raises(ValueError, match="Cannot divide by zero"):
-            divide(10.0, 0.0)
+        assert divide(10.0, 0.0) is None
 
     def test_divide_negative_by_positive(self) -> None:
         """
@@ -137,14 +136,13 @@ class TestPercentageChange:
         """
         assert percentage_change(50.0, 50.0) == pytest.approx(0.0)
 
-    def test_percentage_change_zero_base_raises(self) -> None:
+    def test_percentage_change_zero_base_returns_none(self) -> None:
         """
         GIVEN a zero base_value,
         WHEN percentage_change is called,
-        THEN ValueError is raised.
+        THEN None is returned.
         """
-        with pytest.raises(ValueError, match="zero"):
-            percentage_change(0.0, 100.0)
+        assert percentage_change(0.0, 100.0) is None
 
 
 class TestGreater:
@@ -197,3 +195,19 @@ class TestExp:
         THEN the correct root is returned.
         """
         assert exp(9.0, 0.5) == pytest.approx(3.0)
+
+    def test_exp_negative_base_fractional_exponent_returns_none(self) -> None:
+        """
+        GIVEN a negative base and a fractional exponent,
+        WHEN exp is called,
+        THEN None is returned as the result is not real-valued.
+        """
+        assert exp(-4.0, 0.5) is None
+
+    def test_exp_zero_base_negative_exponent_returns_none(self) -> None:
+        """
+        GIVEN a base of zero and a negative exponent,
+        WHEN exp is called,
+        THEN None is returned as the result is undefined.
+        """
+        assert exp(0.0, -1.0) is None


### PR DESCRIPTION
## Summary

All arithmetic tools in `app/tools.py` (`divide`, `percentage_change`, `exp`) are now defensive against invalid inputs: instead of raising exceptions or silently returning nonsense values, they return `None` and log a `WARNING`. Tests updated and extended to match.

## Why

The evaluation pipeline was vulnerable to crashes whenever the agent produced a bad tool call (e.g. division by zero, or a negative base raised to a fractional exponent). Making these tools return `None` means the pipeline always completes, and the pydantic-ai agent receives `"None"` as the tool result and can reason about it in natural language rather than the run crashing.

## Implementation notes

- **`divide`**: zero denominator previously raised `ValueError` — now returns `None` with a `WARNING` log.
- **`percentage_change`**: zero base previously raised `ValueError` — now returns `None` with a `WARNING` log.
- **`exp`**: two new cases handled:
  - `0 ** negative` previously raised `ZeroDivisionError` — now returns `None` with a `WARNING` log.
  - `negative ** fraction` previously silently returned a complex number (Python's `**` promotes rather than raises) — detected via `isinstance(result, complex)` and returns `None` with a `WARNING` log.
- Return types updated from `float` to `float | None` for all three functions.
- Module docstring updated to document the `None`-return contract.
- `add`, `subtract`, `multiply`, and `greater` have no undefined cases and were left unchanged.
- Returning `None` is safe downstream: pydantic-ai serialises it as the string `"None"` in the message context; nothing downstream does arithmetic on the tool return value directly.

## Testing

- `test_divide_by_zero_raises_value_error` → `test_divide_by_zero_returns_none`
- `test_percentage_change_zero_base_raises` → `test_percentage_change_zero_base_returns_none`
- Two new `exp` tests added: `test_exp_negative_base_fractional_exponent_returns_none` and `test_exp_zero_base_negative_exponent_returns_none`

## Screenshots (optional)

N/A

## Checklist

- [x] Performed self-review
- [x] Manually tested end-to-end
- [x] Written tests for any new functionality
- [ ] Updated the README if appropriate
- [ ] Updated `sample.env` if env vars changed
- [ ] Updated the README env var table if env vars changed
- [x] Conventional commit message used (`feat:`, `fix:`, `chore:`, etc.)
