### PR TITLE
Feature/log file sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist/
 
 .*cache
 
+# Logs
+logs/
+
 
 /app/pyproject.toml
 /app/README.md

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ init:
 	@echo "GID=$$(id -g)" >> .env
 	@echo "" >> .env
 	@awk 'BEGIN{skip=1} /^(UID|GID)=/{next} skip && /^[[:space:]]*$$/{next} {skip=0; print}' sample.env >> .env
-	@mkdir -p data outputs
+	@mkdir -p data outputs logs
 	@echo "Wrote .env with UID=$$(id -u) GID=$$(id -g)"
 	@echo "ACTION REQUIRED: open .env and set OPENAI_API_KEY to your OpenAI API key"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This pipeline evaluates multiple OpenAI models (`gpt-4.1`, `gpt-4o`, `gpt-4o-min
 
 ## Setup
 
-1. Initialise the project — copies `sample.env` to `.env` and creates `data/` and `outputs/` directories:
+1. Initialise the project — copies `sample.env` to `.env` and creates `data/`, `outputs/`, and `logs/` directories:
    ```bash
    make init
    ```
@@ -86,6 +86,7 @@ Results are written to `outputs/<model>_<strategy>/`:
 | `DATA_PATH`      | `/data/convfinqa_dataset.json` | Path to dataset inside the container                                                                  |
 | `RANDOM_SEED`    | `42`                           | Seed for reproducible sampling                                                                        |
 | `MAX_RETRIES`    | `10`                           | Retries for both pydantic-ai tool/validation attempts and OpenAI SDK HTTP retries (429 / 5xx)         |
+| `LOG_FILE`       | `/code/logs/convfinqa.log`     | Path inside the container to write logs (volume-mapped to `logs/convfinqa.log` on the host)           |
 | `UID`            | *(set by `make init`)*         | Host user ID — aligns container's non-root user with host                                             |
 | `GID`            | *(set by `make init`)*         | Host group ID — aligns container's non-root group with host                                           |
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ Results are written to `outputs/<model>_<strategy>/`:
 | ---------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | `OPENAI_API_KEY` | *(required)*                   | Your OpenAI API key                                                                                   |
 | `DATA_PATH`      | `/data/convfinqa_dataset.json` | Path to dataset inside the container                                                                  |
-| `RANDOM_SEED`    | `42`                           | Seed for reproducible sampling                                                                        |
 | `MAX_RETRIES`    | `10`                           | Retries for both pydantic-ai tool/validation attempts and OpenAI SDK HTTP retries (429 / 5xx)         |
-| `LOG_FILE`       | `/code/logs/convfinqa.log`     | Path inside the container to write logs (volume-mapped to `logs/convfinqa.log` on the host)           |
 | `UID`            | *(set by `make init`)*         | Host user ID — aligns container's non-root user with host                                             |
 | `GID`            | *(set by `make init`)*         | Host group ID — aligns container's non-root group with host                                           |
 

--- a/app/data_parser.py
+++ b/app/data_parser.py
@@ -83,7 +83,7 @@ class ConvFinQaDataParser:
     A class to parse ConvFinQa data from a JSON file.
     """
 
-    def __init__(self, data_path: str, load_train_data: bool = True) -> None:
+    def __init__(self, data_path: str, load_train_data: bool) -> None:
         self.data = self._load_json(data_path)
         self.split = "train" if load_train_data else "dev"
 

--- a/app/evaluator.py
+++ b/app/evaluator.py
@@ -17,9 +17,9 @@ class ConversationsEvaluator:
     def __init__(
         self,
         all_convs: list[ConvQA],
-        model_name: ModelName = ModelName.GPT_4_1,
-        prompting_strategy: PromptingStrategy = PromptingStrategy.CHAIN_OF_THOUGHT,
-        sample_size: int = 100,
+        model_name: ModelName,
+        prompting_strategy: PromptingStrategy,
+        sample_size: int,
     ) -> None:
         """Initialise the evaluator with conversations and run configuration.
 

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -22,7 +22,7 @@ class GetAllLlmResponses:
         prompting_strategy: PromptingStrategy = PromptingStrategy.CHAIN_OF_THOUGHT,
         load_train_data: bool = False,
         sample_size: int = 100,
-        use_seed: bool = True,
+        seed: int | None = None,
     ):
         """
         Initialise with model, prompting strategy, and sampling options.
@@ -32,7 +32,7 @@ class GetAllLlmResponses:
             prompting_strategy: The strategy for generating prompts.
             load_train_data: Whether to load training data instead of the dev set.
             sample_size: Number of conversations to randomly sample from the dataset.
-            use_seed: If True, sets a fixed random seed for reproducibility.
+            seed: Random seed for reproducible sampling. If None, sampling is non-deterministic.
         """
         settings = get_settings()
 
@@ -52,9 +52,9 @@ class GetAllLlmResponses:
 
         if sample_size is not None:
             logger.info(f"Sampling {sample_size} conversations from the dataset")
-            if use_seed:
-                logger.info(f"Using fixed random seed {settings.random_seed} for reproducibility")
-                random.seed(settings.random_seed)
+            if seed is not None:
+                logger.info(f"Using fixed random seed {seed} for reproducibility")
+                random.seed(seed)
             self.all_convs = random.sample(self.all_convs, sample_size)
 
         subfolder = f"{model_name.value}_{prompting_strategy.value}"

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -18,11 +18,11 @@ from app.settings import get_settings
 class GetAllLlmResponses:
     def __init__(
         self,
-        model_name: ModelName = ModelName.GPT_4_1,
-        prompting_strategy: PromptingStrategy = PromptingStrategy.CHAIN_OF_THOUGHT,
-        load_train_data: bool = False,
-        sample_size: int = 100,
-        seed: int | None = None,
+        model_name: ModelName,
+        prompting_strategy: PromptingStrategy,
+        load_train_data: bool,
+        sample_size: int,
+        seed: int | None,
     ):
         """
         Initialise with model, prompting strategy, and sampling options.

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,8 @@ from app.agent import ModelName
 from app.evaluator import ConversationsEvaluator
 from app.generate_responses import GetAllLlmResponses
 from app.prompting import PromptingStrategy
-from app.settings import get_settings
+
+LOG_FILE = "/code/logs/convfinqa.log"
 
 app = typer.Typer(
     name="convfinqa",
@@ -33,7 +34,7 @@ def _configure_logging() -> None:
     line is written to the file at the start of each run so individual runs
     are clearly partitioned when reviewing the log.
     """
-    log_file = get_settings().log_file
+    log_file = LOG_FILE
     logger.add(
         log_file,
         level="DEBUG",
@@ -55,7 +56,7 @@ class MainArgs(BaseModel):
     prompting_strategy: PromptingStrategy
     sample_size: int = Field(gt=0)
     use_train_data: bool
-    use_seed: bool
+    seed: int | None = None
 
 
 def main(args: MainArgs) -> None:
@@ -70,7 +71,7 @@ def main(args: MainArgs) -> None:
         prompting_strategy=args.prompting_strategy,
         sample_size=args.sample_size,
         load_train_data=args.use_train_data,
-        use_seed=args.use_seed,
+        seed=args.seed,
     )
     all_convs = asyncio.run(generator.get_all_responses())
 
@@ -94,11 +95,9 @@ def evaluate(
     ),
     sample_size: int = typer.Option(10, help="Number of samples to evaluate"),
     use_train_data: bool = typer.Option(False, help="Use training data instead of dev set"),
-    use_seed: bool = typer.Option(
-        True,
-        help="Use fixed random seed for reproducibility",
-        is_flag=False,
-    ),
+    seed: int | None = typer.Option(
+        None, help="Random seed for reproducible sampling. Omit for non-deterministic sampling."
+    ),  # noqa: B008
 ) -> None:
     """
     Run the ConvFinQA pipeline with specified parameters.
@@ -106,16 +105,16 @@ def evaluate(
     Args:
         model_name: The LLM model to use.
         prompting_strategy: Prompting strategy to use.
-        sample_size (int): Number of samples to evaluate.
-        use_train_data (bool): Whether to use training data instead of dev set.
-        use_seed (bool): Whether to use a fixed random seed for reproducibility.
+        sample_size: Number of samples to evaluate.
+        use_train_data: Whether to use training data instead of dev set.
+        seed: Random seed for reproducible sampling. If omitted, sampling is non-deterministic.
     """
     args = MainArgs(
         model_name=model_name,
         prompting_strategy=prompting_strategy,
         sample_size=sample_size,
         use_train_data=use_train_data,
-        use_seed=use_seed,
+        seed=seed,
     )
 
     _configure_logging()

--- a/app/main.py
+++ b/app/main.py
@@ -52,10 +52,10 @@ def _configure_logging() -> None:
 class MainArgs(BaseModel):
     """Validated arguments for the ConvFinQA pipeline."""
 
-    model_name: ModelName
-    prompting_strategy: PromptingStrategy
-    sample_size: int = Field(gt=0)
-    use_train_data: bool
+    model_name: ModelName = ModelName.GPT_4_1
+    prompting_strategy: PromptingStrategy = PromptingStrategy.CHAIN_OF_THOUGHT
+    sample_size: int = Field(default=10, gt=0)
+    use_train_data: bool = False
     seed: int | None = None
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,10 @@ Main typer app for ConvFinQA
 """
 
 import asyncio
+from datetime import UTC, datetime
 
 import typer
+from loguru import logger
 from pydantic import BaseModel, Field
 from rich import print as rich_print
 from rich.pretty import Pretty
@@ -13,6 +15,7 @@ from app.agent import ModelName
 from app.evaluator import ConversationsEvaluator
 from app.generate_responses import GetAllLlmResponses
 from app.prompting import PromptingStrategy
+from app.settings import get_settings
 
 app = typer.Typer(
     name="convfinqa",
@@ -20,6 +23,29 @@ app = typer.Typer(
     add_completion=True,
     no_args_is_help=True,
 )
+
+
+def _configure_logging() -> None:
+    """Add a file sink to loguru using the default log path from settings.
+
+    The default stderr sink is kept. The file sink rotates at 50 MB and
+    retains the last 5 files so logs do not grow without bound. A separator
+    line is written to the file at the start of each run so individual runs
+    are clearly partitioned when reviewing the log.
+    """
+    log_file = get_settings().log_file
+    logger.add(
+        log_file,
+        level="DEBUG",
+        rotation="50 MB",
+        retention=5,
+        encoding="utf-8",
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level:<8} | {name}:{line} - {message}",
+    )
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(f"\n{'=' * 60}\n  NEW RUN — {timestamp}\n{'=' * 60}\n\n")
+    logger.info(f"Logging to file: {log_file}")
 
 
 class MainArgs(BaseModel):
@@ -92,6 +118,7 @@ def evaluate(
         use_seed=use_seed,
     )
 
+    _configure_logging()
     rich_print("[green]Running ConvFinQA with the following parameters:[/green]")
     rich_print(Pretty(args, expand_all=True))
 

--- a/app/prompting.py
+++ b/app/prompting.py
@@ -135,12 +135,12 @@ class PromptGenerator:
         PromptingStrategy.FEW_SHOT: FewShotPromptStrategy,
     }
 
-    def __init__(self, strategy: PromptingStrategy = PromptingStrategy.BASIC) -> None:
+    def __init__(self, strategy: PromptingStrategy) -> None:
         """
         Initialise the PromptGenerator with a specific strategy.
 
         Args:
-            strategy: The prompting strategy to use. Defaults to basic.
+            strategy: The prompting strategy to use.
         """
         self._strategy = self._STRATEGY_DICT[strategy]()
         logger.info(f"Using prompt strategy: {strategy.value}")

--- a/app/settings.py
+++ b/app/settings.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
         random_seed: Random seed for reproducibility.
         max_retries: Number of retries for both pydantic-ai tool-call / output-validation
             attempts and OpenAI SDK HTTP retries (e.g. on 429 / 5xx responses).
+        log_file: Path to write log output in addition to stderr.
     """
 
     openai_api_key: str = Field(min_length=1)
@@ -27,6 +28,8 @@ class Settings(BaseSettings):
     random_seed: int = Field(default=42, ge=0)
 
     max_retries: int = Field(default=10, ge=0, le=10)
+
+    log_file: str = "/code/logs/convfinqa.log"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "case_sensitive": False, "extra": "ignore"}
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -15,21 +15,15 @@ class Settings(BaseSettings):
     Attributes:
         openai_api_key: API key for OpenAI.
         data_path: Path to the ConvFinQa dataset.
-        random_seed: Random seed for reproducibility.
         max_retries: Number of retries for both pydantic-ai tool-call / output-validation
             attempts and OpenAI SDK HTTP retries (e.g. on 429 / 5xx responses).
-        log_file: Path to write log output in addition to stderr.
     """
 
     openai_api_key: str = Field(min_length=1)
 
     data_path: str = "/data/convfinqa_dataset.json"
 
-    random_seed: int = Field(default=42, ge=0)
-
     max_retries: int = Field(default=10, ge=0, le=10)
-
-    log_file: str = "/code/logs/convfinqa.log"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "case_sensitive": False, "extra": "ignore"}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       - ./tests:/code/tests
       - ./data:/data
       - ./outputs:/code/outputs
+      - ./logs:/code/logs
       - ./pyproject.toml:/code/pyproject.toml
       - ./uv.lock:/code/uv.lock

--- a/sample.env
+++ b/sample.env
@@ -7,7 +7,6 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Application Configuration
 DATA_PATH=/data/convfinqa_dataset.json
-RANDOM_SEED=42
 
 # Retry Configuration
 MAX_RETRIES=10

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -2,8 +2,10 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from app.agent import ModelName
 from app.data_parser import ConvQA, FinancialDoc
 from app.evaluator import ConversationsEvaluator
+from app.prompting import PromptingStrategy
 
 _SAMPLE_DOC = FinancialDoc(
     pre_text="Sample pre text.",
@@ -76,7 +78,12 @@ def test_evaluate_all_conversations_100_percent(
     When: evaluate_all_conversations is called
     Then: It should return 100.0 accuracy
     """
-    evaluator = ConversationsEvaluator(all_convs=perfect_match_conv)
+    evaluator = ConversationsEvaluator(
+        all_convs=perfect_match_conv,
+        model_name=ModelName.GPT_4_1,
+        prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
+        sample_size=1,
+    )
     result: float = evaluator.evaluate_all_conversations()
     assert result == 100.0
 
@@ -91,7 +98,12 @@ def test_evaluate_all_conversations_50_percent(
     When: evaluate_all_conversations is called
     Then: It should return 50.0 accuracy
     """
-    evaluator = ConversationsEvaluator(all_convs=partial_match_conv)
+    evaluator = ConversationsEvaluator(
+        all_convs=partial_match_conv,
+        model_name=ModelName.GPT_4_1,
+        prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
+        sample_size=1,
+    )
     result: float = evaluator.evaluate_all_conversations()
     assert result == 50.0
 
@@ -106,6 +118,11 @@ def test_evaluate_all_conversations_0_percent(
     When: evaluate_all_conversations is called
     Then: It should return 0.0 accuracy
     """
-    evaluator = ConversationsEvaluator(all_convs=no_match_conv)
+    evaluator = ConversationsEvaluator(
+        all_convs=no_match_conv,
+        model_name=ModelName.GPT_4_1,
+        prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
+        sample_size=1,
+    )
     result: float = evaluator.evaluate_all_conversations()
     assert result == 0.0

--- a/tests/test_generate_responses.py
+++ b/tests/test_generate_responses.py
@@ -7,8 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agent import ModelName
 from app.data_parser import ConvQA, FinancialDoc
 from app.generate_responses import GetAllLlmResponses
+from app.prompting import PromptingStrategy
 
 _SAMPLE_DOC = FinancialDoc(
     pre_text="Some introductory text.",
@@ -43,7 +45,13 @@ def generator() -> GetAllLlmResponses:
         mock_parser = MagicMock()
         mock_parser.parse_all_conversations.return_value = []
         mock_parser_cls.return_value = mock_parser
-        instance = GetAllLlmResponses(sample_size=0, seed=None)
+        instance = GetAllLlmResponses(
+            model_name=ModelName.GPT_4_1,
+            prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
+            load_train_data=False,
+            sample_size=0,
+            seed=None,
+        )
     return instance
 
 

--- a/tests/test_generate_responses.py
+++ b/tests/test_generate_responses.py
@@ -43,7 +43,7 @@ def generator() -> GetAllLlmResponses:
         mock_parser = MagicMock()
         mock_parser.parse_all_conversations.return_value = []
         mock_parser_cls.return_value = mock_parser
-        instance = GetAllLlmResponses(sample_size=0, use_seed=False)
+        instance = GetAllLlmResponses(sample_size=0, seed=None)
     return instance
 
 


### PR DESCRIPTION
## Summary

- Adds a loguru file sink (`/code/logs/convfinqa.log`) with a plain-text run separator written at startup, plus a `./logs:/code/logs` Docker volume mount and `make init` support for the `logs/` directory.
- Replaces the `use_seed: bool` / `RANDOM_SEED` env var pair with a single `seed: int | None` argument — pass an integer to seed sampling, omit for non-deterministic runs.
- Centralises all defaults to `MainArgs`; lower-level modules (`GetAllLlmResponses`, `ConversationsEvaluator`, `ConvFinQaDataParser`, `PromptGenerator`) now require explicit arguments instead of carrying their own defaults.

## Why

Persistent log files make it easier to diagnose failures across runs without relying solely on container stdout. The run separator clearly delineates where one execution ends and the next begins. The seed refactor simplifies the interface — a single optional integer is clearer and less error-prone than a boolean flag paired with a separate env var. Centralising defaults to `MainArgs` removes the risk of defaults drifting out of sync across multiple layers of the call stack.

## Implementation notes

- `LOG_FILE = "/code/logs/convfinqa.log"` is a hardcoded constant in `app/main.py`, not a settings field or env var, because it is not user-configurable.
- `_configure_logging()` in `app/main.py` adds the file sink (50 MB rotation, 5 file retention) on top of the existing stderr sink.
- The run separator (timestamp in UTC) is written directly to the log file via `open()` before loguru takes over, so it appears as plain text rather than a structured log line.
- `logs/` is added to `.gitignore`; `make init` creates the directory alongside `data/` and `outputs/`.
- `RANDOM_SEED` removed from `settings.py`, `sample.env`, and the README env var table. `LOG_FILE` is intentionally absent from the env var table.
- All lower-level modules now raise `TypeError` on missing arguments rather than silently falling back to stale defaults; tests updated to pass all required arguments explicitly.

## Testing

- Existing tests in `tests/test_evaluator.py` and `tests/test_generate_responses.py` updated to supply all now-required arguments explicitly.
- All checks pass (`all-checks`).

## Screenshots (optional)

N/A

## Checklist

- [ ] Performed self-review
- [ ] Manually tested end-to-end
- [x] Written tests for any new functionality
- [x] Updated the README if appropriate
- [x] Updated `sample.env` if env vars changed
- [x] Updated the README env var table if env vars changed
- [x] Conventional commit message used (`feat:`, `fix:`, `chore:`, etc.)
