### PR TITLE
Refactor/config and model cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ docker compose exec app bash -ic "pipeline"
 docker compose exec app convfinqa --model-name <model> --prompting-strategy <strategy> --sample-size <n>
 ```
 
-Example — `gpt-4o-mini` with basic prompting, 5 samples:
+Example — `gemini-3.1-flash-lite-preview` with basic prompting, 5 samples:
 
 ```bash
-docker compose exec app convfinqa --model-name openai/gpt-4o-mini --prompting-strategy basic --sample-size 5
+docker compose exec app convfinqa --model-name google/gemini-3.1-flash-lite-preview --prompting-strategy basic --sample-size 5
 ```
 
 | Argument               | Type   | Default            | Acceptable Values                       | Description                           |
 | ---------------------- | ------ | ------------------ | --------------------------------------- | ------------------------------------- |
-| `--model-name`         | string | `openai/gpt-4.1`   | See supported models table below        | Model to evaluate                     |
-| `--prompting-strategy` | string | `chain_of_thought` | `basic`, `chain_of_thought`, `few_shot` | Prompting strategy                    |
+| `--model-name`         | string | `google/gemini-3.1-flash-lite-preview` | See supported models table below        | Model to evaluate                     |
+| `--prompting-strategy` | string | `basic`            | `basic`, `chain_of_thought`, `few_shot` | Prompting strategy                    |
 | `--sample-size`        | int    | `10`               | any positive integer                    | Number of samples                     |
 | `--use-train-data`     | bool   | `False`            | `True`, `False`                         | Use training set instead of test set  |
 | `--seed`               | int    | `None`             | any integer                             | Random seed for reproducible sampling (omit for non-deterministic) |
@@ -92,8 +92,8 @@ docker compose exec app convfinqa --model-name openai/gpt-4o-mini --prompting-st
 | `openai/gpt-5.5`                          | OpenAI    |
 | `anthropic/claude-sonnet-4.5`             | Anthropic |
 | `anthropic/claude-sonnet-4.6`             | Anthropic |
-| `google/gemini-3.1-pro`                   | Google    |
-| `google/gemini-3.1-flash-lite`            | Google    |
+| `google/gemini-3.1-pro-preview`               | Google    |
+| `google/gemini-3.1-flash-lite-preview`        | Google    |
 
 Results are written to `outputs/<model>_<strategy>/`:
 - `convfinqa_responses.json` — per-conversation details
@@ -104,7 +104,6 @@ Results are written to `outputs/<model>_<strategy>/`:
 | Variable             | Default                        | Description                                                                                          |
 | -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | `OPENROUTER_API_KEY` | *(required)*                   | Your OpenRouter API key — grants access to all supported providers (OpenAI, Anthropic, Google, etc.) |
-| `DATA_PATH`          | `/data/convfinqa_dataset.json` | Path to dataset inside the container                                                                 |
 | `MAX_RETRIES`        | `10`                           | Retries for both pydantic-ai tool/validation attempts and OpenAI SDK HTTP retries (429 / 5xx)        |
 | `UID`                | *(set by `make init`)*         | Host user ID — aligns container's non-root user with host                                            |
 | `GID`                | *(set by `make init`)*         | Host group ID — aligns container's non-root group with host                                          |

--- a/README.md
+++ b/README.md
@@ -71,29 +71,29 @@ Example — `gemini-3.1-flash-lite-preview` with basic prompting, 5 samples:
 docker compose exec app convfinqa --model-name google/gemini-3.1-flash-lite-preview --prompting-strategy basic --sample-size 5
 ```
 
-| Argument               | Type   | Default            | Acceptable Values                       | Description                           |
-| ---------------------- | ------ | ------------------ | --------------------------------------- | ------------------------------------- |
-| `--model-name`         | string | `google/gemini-3.1-flash-lite-preview` | See supported models table below        | Model to evaluate                     |
-| `--prompting-strategy` | string | `basic`            | `basic`, `chain_of_thought`, `few_shot` | Prompting strategy                    |
-| `--sample-size`        | int    | `10`               | any positive integer                    | Number of samples                     |
-| `--use-train-data`     | bool   | `False`            | `True`, `False`                         | Use training set instead of test set  |
-| `--seed`               | int    | `None`             | any integer                             | Random seed for reproducible sampling (omit for non-deterministic) |
+| Argument               | Type   | Default                                | Acceptable Values                       | Description                                                        |
+| ---------------------- | ------ | -------------------------------------- | --------------------------------------- | ------------------------------------------------------------------ |
+| `--model-name`         | string | `google/gemini-3.1-flash-lite-preview` | See supported models table below        | Model to evaluate                                                  |
+| `--prompting-strategy` | string | `basic`                                | `basic`, `chain_of_thought`, `few_shot` | Prompting strategy                                                 |
+| `--sample-size`        | int    | `10`                                   | any positive integer                    | Number of samples                                                  |
+| `--use-train-data`     | bool   | `False`                                | `True`, `False`                         | Use training set instead of test set                               |
+| `--seed`               | int    | `None`                                 | any integer                             | Random seed for reproducible sampling (omit for non-deterministic) |
 
 ### Supported Models
 
-| Model | Provider |
-| ----------------------------------------- | --------- |
-| `openai/gpt-4.1`                          | OpenAI    |
-| `openai/gpt-4o`                           | OpenAI    |
-| `openai/gpt-4o-mini`                      | OpenAI    |
-| `openai/o4-mini`                          | OpenAI    |
-| `openai/gpt-5.4`                          | OpenAI    |
-| `openai/gpt-5.4-mini`                     | OpenAI    |
-| `openai/gpt-5.5`                          | OpenAI    |
-| `anthropic/claude-sonnet-4.5`             | Anthropic |
-| `anthropic/claude-sonnet-4.6`             | Anthropic |
-| `google/gemini-3.1-pro-preview`               | Google    |
-| `google/gemini-3.1-flash-lite-preview`        | Google    |
+| Model                                  | Provider  |
+| -------------------------------------- | --------- |
+| `openai/gpt-4.1`                       | OpenAI    |
+| `openai/gpt-4o`                        | OpenAI    |
+| `openai/gpt-4o-mini`                   | OpenAI    |
+| `openai/o4-mini`                       | OpenAI    |
+| `openai/gpt-5.4`                       | OpenAI    |
+| `openai/gpt-5.4-mini`                  | OpenAI    |
+| `openai/gpt-5.5`                       | OpenAI    |
+| `anthropic/claude-sonnet-4.5`          | Anthropic |
+| `anthropic/claude-sonnet-4.6`          | Anthropic |
+| `google/gemini-3.1-pro-preview`        | Google    |
+| `google/gemini-3.1-flash-lite-preview` | Google    |
 
 Results are written to `outputs/<model>_<strategy>/`:
 - `convfinqa_responses.json` — per-conversation details
@@ -101,12 +101,12 @@ Results are written to `outputs/<model>_<strategy>/`:
 
 ## Environment Variables
 
-| Variable             | Default                        | Description                                                                                          |
-| -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `OPENROUTER_API_KEY` | *(required)*                   | Your OpenRouter API key — grants access to all supported providers (OpenAI, Anthropic, Google, etc.) |
-| `MAX_RETRIES`        | `10`                           | Retries for both pydantic-ai tool/validation attempts and OpenAI SDK HTTP retries (429 / 5xx)        |
-| `UID`                | *(set by `make init`)*         | Host user ID — aligns container's non-root user with host                                            |
-| `GID`                | *(set by `make init`)*         | Host group ID — aligns container's non-root group with host                                          |
+| Variable             | Default                | Description                                                                                          |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `OPENROUTER_API_KEY` | *(required)*           | Your OpenRouter API key — grants access to all supported providers (OpenAI, Anthropic, Google, etc.) |
+| `MAX_RETRIES`        | `10`                   | Retries for both pydantic-ai tool/validation attempts and OpenAI SDK HTTP retries (429 / 5xx)        |
+| `UID`                | *(set by `make init`)* | Host user ID — aligns container's non-root user with host                                            |
+| `GID`                | *(set by `make init`)* | Host group ID — aligns container's non-root group with host                                          |
 
 ## Results
 

--- a/app/agent.py
+++ b/app/agent.py
@@ -30,8 +30,8 @@ class ModelName(str, Enum):
     GPT_5_5 = "openai/gpt-5.5"
     CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4.5"
     CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4.6"
-    GEMINI_3_1_PRO = "google/gemini-3.1-pro"
-    GEMINI_3_1_FLASH_LITE = "google/gemini-3.1-flash-lite"
+    GEMINI_3_1_PRO = "google/gemini-3.1-pro-preview"
+    GEMINI_3_1_FLASH_LITE = "google/gemini-3.1-flash-lite-preview"
 
 
 _SYSTEM_PROMPT = (

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -14,6 +14,8 @@ from app.data_parser import ConvFinQaDataParser, ConvQA
 from app.prompting import PromptGenerator, PromptingStrategy
 from app.settings import get_settings
 
+DATA_PATH = "/data/convfinqa_dataset.json"
+
 
 class GetAllLlmResponses:
     def __init__(
@@ -43,7 +45,7 @@ class GetAllLlmResponses:
         )
         self.prompt_gen = PromptGenerator(strategy=prompting_strategy)
 
-        conv_parser = ConvFinQaDataParser(data_path=settings.data_path, load_train_data=load_train_data)
+        conv_parser = ConvFinQaDataParser(data_path=DATA_PATH, load_train_data=load_train_data)
         self.all_convs = conv_parser.parse_all_conversations()
 
         logger.info(

--- a/app/main.py
+++ b/app/main.py
@@ -89,9 +89,9 @@ def main(args: MainArgs) -> None:
 
 @app.command()
 def evaluate(
-    model_name: ModelName = typer.Option(ModelName.GPT_4_1, help="Name of the LLM model to use"),  # noqa: B008
+    model_name: ModelName = typer.Option(ModelName.GEMINI_3_1_FLASH_LITE, help="Name of the LLM model to use"),  # noqa: B008
     prompting_strategy: PromptingStrategy = typer.Option(  # noqa: B008
-        PromptingStrategy.CHAIN_OF_THOUGHT,
+        PromptingStrategy.BASIC,
         help="Prompting strategy to use",
     ),
     sample_size: int = typer.Option(10, help="Number of samples to evaluate"),

--- a/app/settings.py
+++ b/app/settings.py
@@ -14,14 +14,11 @@ class Settings(BaseSettings):
 
     Attributes:
         openrouter_api_key: API key for OpenRouter — grants access to all supported providers.
-        data_path: Path to the ConvFinQa dataset.
         max_retries: Number of retries for both pydantic-ai tool-call / output-validation
             attempts and OpenAI SDK HTTP retries (e.g. on 429 / 5xx responses).
     """
 
     openrouter_api_key: str = Field(min_length=1)
-
-    data_path: str = "/data/convfinqa_dataset.json"
 
     max_retries: int = Field(default=10, ge=0, le=10)
 

--- a/sample.env
+++ b/sample.env
@@ -5,8 +5,5 @@ GID=1000
 # OpenRouter Configuration — single API key for all model providers (OpenAI, Anthropic, Google, etc.)
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
-# Application Configuration
-DATA_PATH=/data/convfinqa_dataset.json
-
 # Retry Configuration
 MAX_RETRIES=10


### PR DESCRIPTION
## Summary

- Removed `DATA_PATH` env var; dataset path is now a hardcoded module-level constant in `generate_responses.py`
- Fixed Gemini model IDs in the `ModelName` enum to include the required `-preview` suffix for OpenRouter
- Changed CLI defaults to `google/gemini-3.1-flash-lite-preview` + `basic` for faster, cheaper smoke tests
- Updated `sample.env` and README to reflect all of the above

## Why

`DATA_PATH` was configurable via the environment but the path never changes in practice, making it needless complexity in `Settings`. The Gemini model IDs were missing the `-preview` suffix required by OpenRouter, causing runtime failures. The previous CLI defaults (`openai/gpt-4.1` + `chain_of_thought`) were slow and expensive for quick iteration.

## Implementation notes

- `DATA_PATH = "/data/convfinqa_dataset.json"` is now a module-level constant at the top of `app/generate_responses.py`, replacing both the `Settings` field and the previous inline string literal.
- `ModelName` enum corrections: `google/gemini-3.1-pro` → `google/gemini-3.1-pro-preview` and `google/gemini-3.1-flash-lite` → `google/gemini-3.1-flash-lite-preview`.
- CLI defaults in `app/main.py` updated to the cheapest/fastest option to reduce friction during development and smoke testing.

## Testing

No new automated tests added. Changes are configuration/constant clean-up with no logic changes. All existing checks should continue to pass.

## Screenshots (optional)

N/A

## Checklist

- [ ] Performed self-review
- [ ] Manually tested end-to-end
- [ ] Written tests for any new functionality
- [x] Updated the README if appropriate
- [x] Updated `sample.env` if env vars changed
- [x] Updated the README env var table if env vars changed
- [x] Conventional commit message used (`feat:`, `fix:`, `chore:`, etc.)
