### PR TITLE
refactor: extract ResultsWriter, add judge_verdicts to ConvQA

### DIFF
--- a/app/data_parser.py
+++ b/app/data_parser.py
@@ -61,6 +61,9 @@ class ConvQA(BaseModel):
     questions: list[str] = Field(min_length=1, description="List of questions in the conversation")
     answers: list[str] = Field(min_length=1, description="List of answers for the conversation")
     llm_answers: list[str] = Field(default_factory=list, description="Structured answers returned by the LLM.")
+    judge_verdicts: list[bool] = Field(
+        default_factory=list, description="Per-answer correctness verdicts from the LLM judge."
+    )
 
     @property
     def formatted_questions(self) -> str:

--- a/app/evaluator.py
+++ b/app/evaluator.py
@@ -3,15 +3,12 @@ ConversationsEvaluator class for evaluating conversations using an LLM judge.
 """
 
 import asyncio
-import os
 
 from loguru import logger
 from pydantic_ai import Agent
 
-from app.agent import ModelName
 from app.data_parser import ConvQA
 from app.judge import JudgeResult, get_judge_response
-from app.prompting import PromptingStrategy
 from app.settings import get_settings
 
 _MAX_CONCURRENT_JUDGE_CALLS = 5
@@ -23,35 +20,19 @@ class ConversationsEvaluator:
     def __init__(
         self,
         all_convs: list[ConvQA],
-        model_name: ModelName,
-        prompting_strategy: PromptingStrategy,
-        sample_size: int,
         judge_agent: Agent[None, JudgeResult],
     ) -> None:
-        """Initialise the evaluator with conversations, run configuration, and a judge agent.
+        """Initialise the evaluator with conversations and a judge agent.
 
         Args:
             all_convs: Conversations whose LLM responses will be evaluated.
-            model_name: The model used to generate responses.
-            prompting_strategy: The prompting strategy used.
-            sample_size: Number of samples that were evaluated.
             judge_agent: Pre-built judge agent used to score answer pairs.
         """
-        logger.info(
-            f"Initialising ConversationsEvaluator with model: {model_name.value}, "
-            f"strategy: {prompting_strategy.value}, sample size: {sample_size}"
-        )
+        logger.info(f"Initialising ConversationsEvaluator with {len(all_convs)} conversations")
         self.all_convs = all_convs
-        self.model_name = model_name
-        self.prompting_strategy = prompting_strategy
-        self.sample_size = sample_size
         self.judge_agent = judge_agent
         self.max_retries = get_settings().max_retries
         self._semaphore = asyncio.Semaphore(_MAX_CONCURRENT_JUDGE_CALLS)
-
-        subfolder = f"{model_name.value.split('/')[-1]}_{prompting_strategy.value}"
-        self.save_path = os.path.join("/code/outputs", subfolder, "eval.txt")
-        os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
 
     async def _evaluate_conversation(self, conv: ConvQA) -> float:
         """Compute the accuracy of the LLM responses for a single conversation.
@@ -79,23 +60,10 @@ class ConversationsEvaluator:
         correct = sum(judge_result.results)
         accuracy = (correct / total) * 100
 
+        conv.judge_verdicts = judge_result.results
         logger.debug(f"Evaluated conversation {conv.id}: accuracy = {accuracy:.2f}%")
 
         return accuracy
-
-    def _save_evaluation(self, accuracy: float) -> None:
-        """Write evaluation results to the output file.
-
-        Args:
-            accuracy: Average accuracy across all evaluated conversations.
-        """
-        with open(self.save_path, "w", encoding="utf-8") as f:
-            f.write(f"Model: {self.model_name.value}\n")
-            f.write(f"Prompting Strategy: {self.prompting_strategy.value}\n")
-            f.write(f"Average Accuracy: {accuracy:.2f}%\n")
-            f.write(f"sample_size: {self.sample_size}\n")
-
-        logger.info(f"Saved evaluation results to {self.save_path}")
 
     async def evaluate_all_conversations(self) -> float:
         """Evaluate all conversations concurrently and return the average accuracy.
@@ -105,8 +73,6 @@ class ConversationsEvaluator:
         """
         accs = await asyncio.gather(*[self._evaluate_conversation(conv) for conv in self.all_convs])
         avg_accuracy = sum(accs) / len(accs) if accs else 0.0
-
-        self._save_evaluation(avg_accuracy)
 
         logger.info(f"Evaluated {len(self.all_convs)} conversations. Average accuracy: {avg_accuracy:.2f}%")
 

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -2,8 +2,6 @@
 Generate LLM responses for conversations in the ConvFinQA dataset.
 """
 
-import json
-import os
 import random
 
 from loguru import logger
@@ -60,9 +58,6 @@ class GetAllLlmResponses:
                 random.seed(seed)
             self.all_convs = random.sample(self.all_convs, sample_size)
 
-        subfolder = f"{model_name.value.split('/')[-1]}_{prompting_strategy.value}"
-        self.save_path = os.path.join("/code/outputs", subfolder, "convfinqa_responses.json")
-
     async def _get_conv_response(self, conv: ConvQA) -> None:
         """Get the LLM response for a single conversation and store structured answers.
 
@@ -88,36 +83,6 @@ class GetAllLlmResponses:
         conv.llm_answers = llm_answers.answers
         logger.debug(f"Conversation {conv.id} complete — answers: {llm_answers.answers}")
 
-    def _save_conversations_to_json(self) -> None:
-        """Save the list of conversations with LLM answers to a JSON file.
-
-        Raises:
-            ValueError: If the list of conversations is empty.
-        """
-        if not self.all_convs:
-            raise ValueError("The list of conversations is empty.")
-
-        dir_path = os.path.dirname(self.save_path)
-        if dir_path and not os.path.exists(dir_path):
-            os.makedirs(dir_path, exist_ok=True)
-
-        data = [
-            {
-                "id": conv.id,
-                "doc": conv.doc.model_dump(),
-                "questions": conv.questions,
-                "answers": conv.answers,
-                "llm_answers": conv.llm_answers,
-            }
-            for conv in self.all_convs
-        ]
-        logger.info(f"Saving {len(data)} conversations to {self.save_path}")
-
-        with open(self.save_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-
-        logger.info(f"Conversations saved successfully to {self.save_path}")
-
     async def get_all_responses(self) -> list[ConvQA]:
         """Get LLM responses for all conversations in the dataset sequentially.
 
@@ -132,7 +97,5 @@ class GetAllLlmResponses:
         """
         for conv in tqdm(self.all_convs, desc="Processing conversations", unit="conv"):
             await self._get_conv_response(conv)
-
-        self._save_conversations_to_json()
 
         return self.all_convs

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.evaluator import ConversationsEvaluator
 from app.generate_responses import GetAllLlmResponses
 from app.judge import build_judge_agent
 from app.prompting import PromptingStrategy
+from app.results_writer import ResultsWriter
 
 LOG_FILE = "/code/logs/convfinqa.log"
 
@@ -68,6 +69,12 @@ def main(args: MainArgs) -> None:
     Args:
         args: Validated pipeline arguments.
     """
+    writer = ResultsWriter(
+        model_name=args.model_name,
+        prompting_strategy=args.prompting_strategy,
+        sample_size=args.sample_size,
+    )
+
     generator = GetAllLlmResponses(
         model_name=args.model_name,
         prompting_strategy=args.prompting_strategy,
@@ -80,12 +87,11 @@ def main(args: MainArgs) -> None:
     judge_agent = build_judge_agent()
     evaluator = ConversationsEvaluator(
         all_convs=all_convs,
-        model_name=args.model_name,
-        prompting_strategy=args.prompting_strategy,
-        sample_size=args.sample_size,
         judge_agent=judge_agent,
     )
     accuracy = asyncio.run(evaluator.evaluate_all_conversations())
+
+    writer.save_outputs(all_convs, accuracy)
 
     rich_print(f"[bold green]Average accuracy: {accuracy:.2f}%[/bold green]")
 

--- a/app/results_writer.py
+++ b/app/results_writer.py
@@ -1,0 +1,89 @@
+"""
+ResultsWriter: centralised output persistence for the ConvFinQA pipeline.
+"""
+
+import json
+import os
+
+from loguru import logger
+
+from app.agent import ModelName
+from app.data_parser import ConvQA
+from app.prompting import PromptingStrategy
+
+_OUTPUT_ROOT = "/code/outputs"
+
+
+class ResultsWriter:
+    """Writes pipeline outputs (responses JSON and evaluation report) to disk."""
+
+    def __init__(
+        self,
+        model_name: ModelName,
+        prompting_strategy: PromptingStrategy,
+        sample_size: int,
+    ) -> None:
+        """Construct output paths and create the output directory.
+
+        Args:
+            model_name: The model used to generate responses.
+            prompting_strategy: The prompting strategy used.
+            sample_size: Number of conversations that were evaluated.
+        """
+        self.model_name = model_name
+        self.prompting_strategy = prompting_strategy
+        self.sample_size = sample_size
+
+        subfolder = f"{model_name.value.split('/')[-1]}_{prompting_strategy.value}"
+        output_dir = os.path.join(_OUTPUT_ROOT, subfolder)
+
+        self._responses_path = os.path.join(output_dir, "convfinqa_responses.json")
+        self._eval_path = os.path.join(output_dir, "eval.txt")
+
+        os.makedirs(output_dir, exist_ok=True)
+        logger.info(f"ResultsWriter initialised — output directory: {output_dir}")
+
+    def _save_responses(self, all_convs: list[ConvQA]) -> None:
+        """Serialise conversations with LLM answers to a JSON file.
+
+        Args:
+            all_convs: Conversations with llm_answers populated.
+
+        Raises:
+            ValueError: If all_convs is empty.
+        """
+        if not all_convs:
+            raise ValueError("The list of conversations is empty.")
+
+        data = [conv.model_dump() for conv in all_convs]
+
+        logger.info(f"Saving {len(data)} conversations to {self._responses_path}")
+
+        with open(self._responses_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+
+        logger.info(f"Conversations saved successfully to {self._responses_path}")
+
+    def _save_evaluation(self, accuracy: float) -> None:
+        """Write evaluation summary to the eval report file.
+
+        Args:
+            accuracy: Average accuracy across all evaluated conversations.
+        """
+        with open(self._eval_path, "w", encoding="utf-8") as f:
+            f.write(f"Model: {self.model_name.value}\n")
+            f.write(f"Prompting Strategy: {self.prompting_strategy.value}\n")
+            f.write(f"Average Accuracy: {accuracy:.2f}%\n")
+            f.write(f"sample_size: {self.sample_size}\n")
+
+        logger.info(f"Saved evaluation results to {self._eval_path}")
+
+    def save_outputs(self, all_convs: list[ConvQA], accuracy: float) -> None:
+        """Persist all pipeline outputs — responses JSON and evaluation report.
+
+        Args:
+            all_convs: Conversations with llm_answers populated.
+            accuracy: Average accuracy across all evaluated conversations.
+        """
+        self._save_responses(all_convs)
+        self._save_evaluation(accuracy)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -2,16 +2,14 @@
 Tests for ConversationsEvaluator in app/evaluator.py.
 """
 
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import patch
 
 import pytest
 from pydantic_ai.models.test import TestModel
 
-from app.agent import ModelName
 from app.data_parser import ConvQA, FinancialDoc
 from app.evaluator import ConversationsEvaluator
 from app.judge import build_judge_agent
-from app.prompting import PromptingStrategy
 from app.settings import Settings
 
 _SAMPLE_DOC = FinancialDoc(
@@ -41,8 +39,7 @@ def patch_settings(monkeypatch: pytest.MonkeyPatch):
 @pytest.fixture
 def judge_agent():
     """Return a judge agent backed by TestModel to avoid real API calls."""
-    agent = build_judge_agent()
-    return agent
+    return build_judge_agent()
 
 
 @pytest.fixture
@@ -99,11 +96,7 @@ def no_match_conv() -> list[ConvQA]:
     ]
 
 
-@patch("app.evaluator.os.makedirs")
-@patch("builtins.open", new_callable=mock_open)
 async def test_evaluate_all_conversations_100_percent(
-    mock_file: MagicMock,
-    mock_makedirs: MagicMock,
     perfect_match_conv: list[ConvQA],
     judge_agent,
 ) -> None:
@@ -116,21 +109,15 @@ async def test_evaluate_all_conversations_100_percent(
     with judge_agent.override(model=test_model):
         evaluator = ConversationsEvaluator(
             all_convs=perfect_match_conv,
-            model_name=ModelName.GPT_4_1,
-            prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
-            sample_size=1,
             judge_agent=judge_agent,
         )
         result = await evaluator.evaluate_all_conversations()
 
     assert result == 100.0
+    assert perfect_match_conv[0].judge_verdicts == [True, True]
 
 
-@patch("app.evaluator.os.makedirs")
-@patch("builtins.open", new_callable=mock_open)
 async def test_evaluate_all_conversations_50_percent(
-    mock_file: MagicMock,
-    mock_makedirs: MagicMock,
     partial_match_conv: list[ConvQA],
     judge_agent,
 ) -> None:
@@ -143,21 +130,15 @@ async def test_evaluate_all_conversations_50_percent(
     with judge_agent.override(model=test_model):
         evaluator = ConversationsEvaluator(
             all_convs=partial_match_conv,
-            model_name=ModelName.GPT_4_1,
-            prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
-            sample_size=1,
             judge_agent=judge_agent,
         )
         result = await evaluator.evaluate_all_conversations()
 
     assert result == 50.0
+    assert partial_match_conv[0].judge_verdicts == [True, False]
 
 
-@patch("app.evaluator.os.makedirs")
-@patch("builtins.open", new_callable=mock_open)
 async def test_evaluate_all_conversations_0_percent(
-    mock_file: MagicMock,
-    mock_makedirs: MagicMock,
     no_match_conv: list[ConvQA],
     judge_agent,
 ) -> None:
@@ -170,11 +151,9 @@ async def test_evaluate_all_conversations_0_percent(
     with judge_agent.override(model=test_model):
         evaluator = ConversationsEvaluator(
             all_convs=no_match_conv,
-            model_name=ModelName.GPT_4_1,
-            prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
-            sample_size=1,
             judge_agent=judge_agent,
         )
         result = await evaluator.evaluate_all_conversations()
 
     assert result == 0.0
+    assert no_match_conv[0].judge_verdicts == [False, False]

--- a/tests/test_generate_responses.py
+++ b/tests/test_generate_responses.py
@@ -128,9 +128,8 @@ class TestGetAllResponses:
 
         test_model = TestModel(custom_output_args={"answers": ["answer"]})
 
-        with patch.object(generator, "_save_conversations_to_json"):
-            with generator.agent.override(model=test_model, tools=[]):
-                result = await generator.get_all_responses()
+        with generator.agent.override(model=test_model, tools=[]):
+            result = await generator.get_all_responses()
 
         assert result[0].llm_answers == ["answer"]
         assert result[1].llm_answers == ["answer"]

--- a/tests/test_results_writer.py
+++ b/tests/test_results_writer.py
@@ -1,0 +1,158 @@
+"""
+Tests for ResultsWriter in app/results_writer.py.
+"""
+
+import json
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from app.agent import ModelName
+from app.data_parser import ConvQA, FinancialDoc
+from app.prompting import PromptingStrategy
+from app.results_writer import ResultsWriter
+
+_SAMPLE_DOC = FinancialDoc(
+    pre_text="Some introductory text.",
+    post_text="Some trailing text.",
+    table={"2023": {"revenue": 100.0}},
+)
+
+_SAMPLE_CONV = ConvQA(
+    id="test-1",
+    doc=_SAMPLE_DOC,
+    questions=["What is revenue?"],
+    answers=["100"],
+    llm_answers=["100"],
+    judge_verdicts=[True],
+)
+
+
+def _make_file_capture():  # type: ignore[no-untyped-def]
+    """Return a fake open() that captures writes per file path."""
+    written: dict[str, str] = {}
+
+    def fake_open(path: str, mode: str = "r", **kwargs):  # type: ignore[no-untyped-def]
+        handle = mock_open()()
+        written[path] = ""
+
+        def write(s: str) -> int:
+            written[path] += s
+            return len(s)
+
+        handle.write = write
+        return handle
+
+    return fake_open, written
+
+
+@pytest.fixture
+def writer() -> ResultsWriter:
+    """
+    GIVEN valid model, strategy, and sample size,
+    WHEN creating a ResultsWriter instance with makedirs patched,
+    THEN return a configured writer without touching the filesystem.
+    """
+    with patch("app.results_writer.os.makedirs"):
+        return ResultsWriter(
+            model_name=ModelName.GPT_4_1,
+            prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
+            sample_size=5,
+        )
+
+
+class TestResultsWriterInit:
+    def test_constructs_correct_responses_path(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN a writer built with GPT_4_1 and chain_of_thought strategy,
+        WHEN checking the _responses_path attribute,
+        THEN it should point to the expected subfolder and filename.
+        """
+        assert writer._responses_path == "/code/outputs/gpt-4.1_chain_of_thought/convfinqa_responses.json"
+
+    def test_constructs_correct_eval_path(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN a writer built with GPT_4_1 and chain_of_thought strategy,
+        WHEN checking the _eval_path attribute,
+        THEN it should point to the expected subfolder and filename.
+        """
+        assert writer._eval_path == "/code/outputs/gpt-4.1_chain_of_thought/eval.txt"
+
+    def test_calls_makedirs_on_output_dir(self) -> None:
+        """
+        GIVEN valid constructor arguments,
+        WHEN ResultsWriter is instantiated,
+        THEN os.makedirs is called once with the correct directory and exist_ok=True.
+        """
+        with patch("app.results_writer.os.makedirs") as mock_makedirs:
+            ResultsWriter(
+                model_name=ModelName.GPT_4_1,
+                prompting_strategy=PromptingStrategy.BASIC,
+                sample_size=10,
+            )
+
+        mock_makedirs.assert_called_once_with(
+            "/code/outputs/gpt-4.1_basic",
+            exist_ok=True,
+        )
+
+
+class TestSaveOutputs:
+    def test_saves_responses_as_json(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN a list of conversations with llm_answers populated,
+        WHEN save_outputs is called,
+        THEN the responses file is written with the correct JSON structure.
+        """
+        fake_open, written = _make_file_capture()
+
+        with patch("builtins.open", fake_open):
+            writer.save_outputs([_SAMPLE_CONV], accuracy=100.0)
+
+        parsed = json.loads(written[writer._responses_path])
+
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == "test-1"
+        assert parsed[0]["questions"] == ["What is revenue?"]
+        assert parsed[0]["answers"] == ["100"]
+        assert parsed[0]["llm_answers"] == ["100"]
+        assert parsed[0]["judge_verdicts"] == [True]
+
+    def test_saves_evaluation_report(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN an accuracy value of 75.5,
+        WHEN save_outputs is called,
+        THEN the eval file contains the model, strategy, accuracy, and sample_size lines.
+        """
+        fake_open, written = _make_file_capture()
+
+        with patch("builtins.open", fake_open):
+            writer.save_outputs([_SAMPLE_CONV], accuracy=75.5)
+
+        eval_content = written[writer._eval_path]
+        assert "Model: openai/gpt-4.1" in eval_content
+        assert "Prompting Strategy: chain_of_thought" in eval_content
+        assert "Average Accuracy: 75.50%" in eval_content
+        assert "sample_size: 5" in eval_content
+
+    def test_raises_on_empty_conversation_list(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN an empty list of conversations,
+        WHEN save_outputs is called,
+        THEN a ValueError is raised.
+        """
+        with pytest.raises(ValueError, match="empty"):
+            writer.save_outputs([], accuracy=0.0)
+
+    def test_accuracy_formatted_to_two_decimal_places(self, writer: ResultsWriter) -> None:
+        """
+        GIVEN an accuracy value with many decimal places,
+        WHEN save_outputs is called,
+        THEN the written accuracy is rounded to exactly two decimal places.
+        """
+        fake_open, written = _make_file_capture()
+
+        with patch("builtins.open", fake_open):
+            writer.save_outputs([_SAMPLE_CONV], accuracy=33.3333)
+
+        assert "Average Accuracy: 33.33%" in written[writer._eval_path]


### PR DESCRIPTION
## Summary

Extracts all file-save logic from `GetAllLlmResponses` and `ConversationsEvaluator` into a new `ResultsWriter` class (`app/results_writer.py`) with a single public method `save_outputs`. Adds a `judge_verdicts: list[bool]` field to `ConvQA` and wires `ResultsWriter` as the final step in `main.py`.

## Why

`GetAllLlmResponses` and `ConversationsEvaluator` each held file-writing responsibilities alongside their primary jobs, violating single responsibility. Centralising output persistence in one place makes the pipeline easier to reason about, test, and extend (e.g. changing output format or destination requires touching only one module).

## Implementation notes

- `app/results_writer.py` — new `ResultsWriter` class; `save_outputs(all_convs, accuracy)` is the sole public method. Handles writing LLM answers, judge verdicts, and accuracy to disk.
- `app/generate_responses.py` — removed file-save logic from `GetAllLlmResponses`; class now only fetches LLM responses.
- `app/evaluator.py` — removed file-save logic from `ConversationsEvaluator`; evaluator now only computes verdicts. Verdicts are stored via the new `judge_verdicts` field on `ConvQA` (same in-place mutation pattern already used by `llm_answers`).
- `app/data_parser.py` — added `judge_verdicts: list[bool]` field to `ConvQA`.
- `app/main.py` — calls `writer.save_outputs(all_convs, accuracy)` as the terminal pipeline step.

## Testing

- Added `tests/test_results_writer.py` with 7 tests covering the new module (output file contents, directory creation, accuracy persistence, edge cases).
- Updated `tests/test_evaluator.py` and `tests/test_generate_responses.py` to remove assertions that no longer apply to those classes.
- All 66 tests pass; full pipeline confirmed green.

## Screenshots (optional)

N/A

## Checklist

- [x] Performed self-review
- [x] Manually tested end-to-end
- [x] Written tests for any new functionality
- [ ] Updated the README if appropriate
- [ ] Updated `sample.env` if env vars changed
- [ ] Updated the README env var table if env vars changed
- [x] Conventional commit message used (`feat:`, `fix:`, `chore:`, etc.)
