### PR TITLE
refactor: extract models.py and log.py, clean up cross-module imports

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -3,7 +3,6 @@ Pydantic AI agent setup for the ConvFinQA financial question-answering pipeline.
 """
 
 import asyncio
-from enum import Enum
 
 import openai
 from loguru import logger
@@ -14,27 +13,11 @@ from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettin
 from pydantic_ai.providers.openrouter import OpenRouterProvider
 from pydantic_ai.usage import UsageLimits
 
+from app.models import ModelName
 from app.settings import get_settings
 from app.tools import add, divide, exp, greater, multiply, percentage_change, subtract
 
 _INITIAL_RETRY_DELAY_SECONDS = 1.0
-
-
-class ModelName(str, Enum):
-    """Enum for supported model names, using OpenRouter provider-prefixed identifiers."""
-
-    GPT_4_1 = "openai/gpt-4.1"
-    GPT_4O = "openai/gpt-4o"
-    GPT_4O_MINI = "openai/gpt-4o-mini"
-    O4_MINI = "openai/o4-mini"
-    GPT_5_4 = "openai/gpt-5.4"
-    GPT_5_4_MINI = "openai/gpt-5.4-mini"
-    GPT_5_5 = "openai/gpt-5.5"
-    CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4.5"
-    CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4.6"
-    GEMINI_3_1_PRO = "google/gemini-3.1-pro-preview"
-    GEMINI_3_1_FLASH_LITE = "google/gemini-3.1-flash-lite-preview"
-
 
 _SYSTEM_PROMPT = (
     "You are a financial question-answering assistant.\n"
@@ -86,8 +69,8 @@ def build_agent(
     where tool call responses omit the arguments field, causing placeholder answers.
 
     max_retries is applied at two levels:
-    - HTTP level: passed to the underlying AsyncOpenAI client for 429/5xx retries
-    - Agent level: passed to pydantic-ai for tool-call and output-validation retries
+    - HTTP level: passed to the underlying AsyncOpenAI client for 429/5xx retries.
+    - Agent level: passed to pydantic-ai for tool-call and output-validation retries.
 
     Args:
         model_name: The model to use, identified by its OpenRouter provider-prefixed string.
@@ -119,10 +102,16 @@ def build_agent(
     )
 
 
-_INITIAL_RETRY_DELAY_SECONDS = 1.0
-
-
 async def _run_agent(agent: Agent[None, LlmAnswers], prompt: str) -> LlmAnswers | None:
+    """Run the agent once and return output, or None if the request limit is exceeded.
+
+    Args:
+        agent: The configured pydantic-ai Agent.
+        prompt: The user prompt containing the financial document and questions.
+
+    Returns:
+        Validated LlmAnswers, or None if UsageLimitExceeded.
+    """
     try:
         result = await agent.run(prompt, usage_limits=UsageLimits(request_limit=25))
     except UsageLimitExceeded:

--- a/app/data_parser.py
+++ b/app/data_parser.py
@@ -1,108 +1,41 @@
 """
-Parses ConvFinQa data from a JSON file and provides methods to access question-answer pairs and documents.
+Parses ConvFinQA data from a JSON file into typed ConvQA objects.
 """
 
 import json
 import os
-from typing import Any, Self, cast
+from typing import Any, cast
 
 from loguru import logger
-from pydantic import BaseModel, Field, model_validator
 
-
-class FinancialDoc(BaseModel):
-    """Structured representation of a financial document with text and tabular data."""
-
-    pre_text: str = Field(description="Introductory text preceding the table.")
-    post_text: str = Field(description="Explanatory text following the table.")
-    table: dict[str, dict[str, float | str | None]] = Field(description="Tabular data keyed by column then row label.")
-
-    def _format_table(self) -> str:
-        """Render the table dict as a plain-text grid.
-
-        Returns:
-            A tab-separated grid with column headers and row labels.
-        """
-        if not self.table:
-            return ""
-
-        columns = list(self.table.keys())
-        row_labels = list(next(iter(self.table.values())).keys())
-
-        header = "\t".join([""] + columns)
-        rows = ["\t".join([label] + [str(self.table[col].get(label, "")) for col in columns]) for label in row_labels]
-        return "\n".join([header] + rows)
-
-    @property
-    def formatted_doc(self) -> str:
-        """Render the document as a readable string for use in prompts.
-
-        Returns:
-            A formatted string combining pre_text, the table as a grid, and post_text.
-        """
-        return "\n\n".join(
-            [
-                self.pre_text,
-                self._format_table(),
-                self.post_text,
-            ]
-        )
-
-
-class ConvQA(BaseModel):
-    """
-    Class to represent a conversation question-answer pair.
-
-    Provides validation and formatting for financial conversation data.
-    """
-
-    id: str = Field(min_length=1, description="Unique identifier for the conversation")
-    doc: FinancialDoc = Field(description="The structured financial document related to the conversation")
-    questions: list[str] = Field(min_length=1, description="List of questions in the conversation")
-    answers: list[str] = Field(min_length=1, description="List of answers for the conversation")
-    llm_answers: list[str] = Field(default_factory=list, description="Structured answers returned by the LLM.")
-    judge_verdicts: list[bool] = Field(
-        default_factory=list, description="Per-answer correctness verdicts from the LLM judge."
-    )
-
-    @property
-    def formatted_questions(self) -> str:
-        """Format questions with delimiter for prompt generation."""
-        return " {next_question} ".join(self.questions)
-
-    @model_validator(mode="after")
-    def validate_questions_and_answers_same_length(self) -> Self:
-        """Validate that questions and answers lists have the same length."""
-        if len(self.questions) != len(self.answers):
-            raise ValueError(
-                f"Document {self.id}: Questions and answers must have the same length. "
-                f"Got {len(self.questions)} questions and {len(self.answers)} answers."
-            )
-        return self
+from app.models import ConvQA, FinancialDoc
 
 
 class ConvFinQaDataParser:
-    """
-    A class to parse ConvFinQa data from a JSON file.
-    """
+    """Parses the ConvFinQA JSON dataset into a list of ConvQA instances."""
 
     def __init__(self, data_path: str, load_train_data: bool) -> None:
+        """Initialise the parser and load raw JSON from disk.
+
+        Args:
+            data_path: Path to the ConvFinQA JSON dataset file.
+            load_train_data: If True, use the training split; otherwise use the dev split.
+        """
         self.data = self._load_json(data_path)
         self.split = "train" if load_train_data else "dev"
 
     def _load_json(self, data_path: str) -> dict[str, Any]:
-        """
-        Load JSON data from a file.
+        """Load JSON data from a file.
 
         Args:
-            data_path (str): The path to the JSON file.
+            data_path: The path to the JSON file.
+
+        Returns:
+            The loaded JSON data as a dictionary.
 
         Raises:
             FileNotFoundError: If the file does not exist.
-            ValueError: If the file is not a valid JSON file or if there is an error decoding the JSON.
-
-        Returns:
-            dict[str, Any]: The loaded JSON data as a dictionary.
+            ValueError: If the file is not valid JSON or does not have a .json extension.
         """
         if not os.path.exists(data_path):
             raise FileNotFoundError(f"The file {data_path} does not exist.")
@@ -113,38 +46,34 @@ class ConvFinQaDataParser:
         try:
             with open(data_path, encoding="utf-8") as file:
                 logger.info(f"Loading data from {data_path}")
-                data = cast(dict[str, Any], json.load(file))
-                return data
+                return cast(dict[str, Any], json.load(file))
         except json.JSONDecodeError as e:
             raise ValueError(f"Error decoding JSON from the file {data_path}: {e}") from e
 
     def _parse_questions_and_answers(self, idx: int) -> tuple[list[str], list[str]]:
-        """
-        Parse questions and answers from the dialogue at the given index.
+        """Parse questions and answers from the dialogue at the given index.
 
         Args:
-            idx (int): The index of the entry.
+            idx: The index of the entry.
 
         Returns:
-            tuple[list[str], list[str]]: A tuple containing a list of questions and a list of answers.
+            A tuple of (questions, answers) lists.
         """
         if idx < 0:
             raise ValueError("Index must be a non-negative integer.")
 
         questions = self.data[self.split][idx]["dialogue"]["conv_questions"]
         answers = self.data[self.split][idx]["dialogue"]["conv_answers"]
-
         return questions, answers
 
     def _parse_document(self, idx: int) -> FinancialDoc:
-        """
-        Parse the financial document at the given index.
+        """Parse the financial document at the given index.
 
         Args:
-            idx (int): The index of the entry.
+            idx: The index of the entry.
 
         Returns:
-            FinancialDoc: The structured financial document.
+            The structured financial document.
         """
         if idx < 0:
             raise ValueError("Index must be a non-negative integer.")
@@ -152,14 +81,13 @@ class ConvFinQaDataParser:
         return FinancialDoc.model_validate(self.data[self.split][idx]["doc"])
 
     def _parse_document_id(self, idx: int) -> str:
-        """
-        Parse the document ID at the given index.
+        """Parse the document ID at the given index.
 
         Args:
-            idx (int): The index of the entry.
+            idx: The index of the entry.
 
         Returns:
-            str: The document ID.
+            The document ID string.
         """
         if idx < 0:
             raise ValueError("Index must be a non-negative integer.")
@@ -167,14 +95,13 @@ class ConvFinQaDataParser:
         return cast(str, self.data[self.split][idx]["id"])
 
     def _parse_conversation(self, idx: int) -> ConvQA:
-        """
-        Parse a single conversation entry at the given index.
+        """Parse a single conversation entry at the given index.
 
         Args:
-            idx (int): The index of the entry.
+            idx: The index of the entry.
 
         Returns:
-            ConvQA: An instance of ConvQA containing the document, questions, and answers.
+            A ConvQA instance containing the document, questions, and answers.
         """
         if idx < 0:
             raise ValueError("Index must be a non-negative integer.")
@@ -185,10 +112,9 @@ class ConvFinQaDataParser:
         return ConvQA(id=id, doc=doc, questions=questions, answers=answers)
 
     def parse_all_conversations(self) -> list[ConvQA]:
-        """
-        Parse all conversation entries from the selected split.
+        """Parse all conversation entries from the selected split.
 
         Returns:
-            list[ConvQA]: A list of ConvQA instances containing all documents, questions, and answers.
+            A list of ConvQA instances for every entry in the split.
         """
         return [self._parse_conversation(idx) for idx in range(len(self.data[self.split]))]

--- a/app/evaluator.py
+++ b/app/evaluator.py
@@ -7,8 +7,8 @@ import asyncio
 from loguru import logger
 from pydantic_ai import Agent
 
-from app.data_parser import ConvQA
 from app.judge import JudgeResult, get_judge_response
+from app.models import ConvQA
 from app.settings import get_settings
 
 _MAX_CONCURRENT_JUDGE_CALLS = 5

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -7,9 +7,10 @@ import random
 from loguru import logger
 from tqdm import tqdm
 
-from app.agent import LlmAnswers, ModelName, build_agent, get_response
-from app.data_parser import ConvFinQaDataParser, ConvQA
-from app.prompting import PromptGenerator, PromptingStrategy
+from app.agent import LlmAnswers, build_agent, get_response
+from app.data_parser import ConvFinQaDataParser
+from app.models import ConvQA, ModelName, PromptingStrategy
+from app.prompting import PromptGenerator
 from app.settings import get_settings
 
 DATA_PATH = "/data/convfinqa_dataset.json"

--- a/app/generate_responses.py
+++ b/app/generate_responses.py
@@ -5,11 +5,12 @@ Generate LLM responses for conversations in the ConvFinQA dataset.
 import random
 
 from loguru import logger
+from pydantic_ai import Agent
 from tqdm import tqdm
 
-from app.agent import LlmAnswers, build_agent, get_response
+from app.agent import LlmAnswers, get_response
 from app.data_parser import ConvFinQaDataParser
-from app.models import ConvQA, ModelName, PromptingStrategy
+from app.models import ConvQA, PromptingStrategy
 from app.prompting import PromptGenerator
 from app.settings import get_settings
 
@@ -19,17 +20,17 @@ DATA_PATH = "/data/convfinqa_dataset.json"
 class GetAllLlmResponses:
     def __init__(
         self,
-        model_name: ModelName,
+        agent: Agent[None, LlmAnswers],
         prompting_strategy: PromptingStrategy,
         load_train_data: bool,
         sample_size: int,
         seed: int | None,
     ):
         """
-        Initialise with model, prompting strategy, and sampling options.
+        Initialise with a pre-built agent, prompting strategy, and sampling options.
 
         Args:
-            model_name: The LLM model to use.
+            agent: Pre-built pydantic-ai Agent configured for LLM inference.
             prompting_strategy: The strategy for generating prompts.
             load_train_data: Whether to load training data instead of the dev set.
             sample_size: Number of conversations to randomly sample from the dataset.
@@ -38,19 +39,13 @@ class GetAllLlmResponses:
         settings = get_settings()
 
         self.max_retries = settings.max_retries
-        self.agent = build_agent(
-            model_name=model_name,
-            max_retries=settings.max_retries,
-        )
+        self.agent = agent
         self.prompt_gen = PromptGenerator(strategy=prompting_strategy)
 
         conv_parser = ConvFinQaDataParser(data_path=DATA_PATH, load_train_data=load_train_data)
         self.all_convs = conv_parser.parse_all_conversations()
 
-        logger.info(
-            f"Initialising GetAllLlmResponses with model: {model_name.value}, "
-            f"and prompting strategy: {prompting_strategy.value}"
-        )
+        logger.info(f"Initialising GetAllLlmResponses with prompting strategy: {prompting_strategy.value}")
 
         if sample_size is not None:
             logger.info(f"Sampling {sample_size} conversations from the dataset")

--- a/app/judge.py
+++ b/app/judge.py
@@ -14,7 +14,7 @@ from pydantic_ai import Agent
 from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings, OpenRouterProviderConfig
 from pydantic_ai.providers.openrouter import OpenRouterProvider
 
-from app.agent import ModelName
+from app.models import ModelName
 from app.settings import get_settings
 
 _JUDGE_MODEL = ModelName.GEMINI_3_1_FLASH_LITE

--- a/app/log.py
+++ b/app/log.py
@@ -1,0 +1,37 @@
+"""
+Logging configuration for the ConvFinQA pipeline.
+
+Wires loguru sinks at application startup. Call configure_logging() once from
+the entry point before any other module emits log messages.
+"""
+
+from datetime import UTC, datetime
+
+from loguru import logger
+
+_LOG_FILE = "/code/logs/convfinqa.log"
+_LOG_ROTATION = "50 MB"
+_LOG_RETENTION = 5
+_LOG_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} | {level:<8} | {name}:{line} - {message}"
+
+
+def configure_logging() -> None:
+    """Add a rotating file sink to loguru and write a run-separator banner.
+
+    The default stderr sink is kept. The file sink rotates at 50 MB and retains
+    the last 5 files so logs do not grow without bound. A separator banner is
+    written at the start of each run so individual runs are clearly partitioned
+    when reviewing the log file.
+    """
+    logger.add(
+        _LOG_FILE,
+        level="DEBUG",
+        rotation=_LOG_ROTATION,
+        retention=_LOG_RETENTION,
+        encoding="utf-8",
+        format=_LOG_FORMAT,
+    )
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    with open(_LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"\n{'=' * 60}\n  NEW RUN — {timestamp}\n{'=' * 60}\n\n")
+    logger.info(f"Logging to file: {_LOG_FILE}")

--- a/app/main.py
+++ b/app/main.py
@@ -10,12 +10,14 @@ from pydantic import BaseModel
 from rich import print as rich_print
 from rich.pretty import Pretty
 
+from app.agent import build_agent
 from app.evaluator import ConversationsEvaluator
 from app.generate_responses import GetAllLlmResponses
 from app.judge import build_judge_agent
 from app.log import configure_logging
 from app.models import ModelName, PromptingStrategy
 from app.results_writer import ResultsWriter
+from app.settings import get_settings
 
 app = typer.Typer(
     name="convfinqa",
@@ -50,8 +52,10 @@ def main(args: MainArgs) -> None:
         sample_size=args.sample_size,
     )
 
+    settings = get_settings()
+    agent = build_agent(model_name=args.model_name, max_retries=settings.max_retries)
     generator = GetAllLlmResponses(
-        model_name=args.model_name,
+        agent=agent,
         prompting_strategy=args.prompting_strategy,
         sample_size=args.sample_size,
         load_train_data=args.use_train_data,

--- a/app/main.py
+++ b/app/main.py
@@ -1,25 +1,21 @@
 """
-Main typer app for ConvFinQA
+CLI entry point for the ConvFinQA evaluation pipeline.
 """
 
 import asyncio
-from datetime import UTC, datetime
 from typing import Optional
 
 import typer
-from loguru import logger
 from pydantic import BaseModel
 from rich import print as rich_print
 from rich.pretty import Pretty
 
-from app.agent import ModelName
 from app.evaluator import ConversationsEvaluator
 from app.generate_responses import GetAllLlmResponses
 from app.judge import build_judge_agent
-from app.prompting import PromptingStrategy
+from app.log import configure_logging
+from app.models import ModelName, PromptingStrategy
 from app.results_writer import ResultsWriter
-
-LOG_FILE = "/code/logs/convfinqa.log"
 
 app = typer.Typer(
     name="convfinqa",
@@ -27,29 +23,6 @@ app = typer.Typer(
     add_completion=True,
     no_args_is_help=True,
 )
-
-
-def _configure_logging() -> None:
-    """Add a file sink to loguru using the default log path from settings.
-
-    The default stderr sink is kept. The file sink rotates at 50 MB and
-    retains the last 5 files so logs do not grow without bound. A separator
-    line is written to the file at the start of each run so individual runs
-    are clearly partitioned when reviewing the log.
-    """
-    log_file = LOG_FILE
-    logger.add(
-        log_file,
-        level="DEBUG",
-        rotation="50 MB",
-        retention=5,
-        encoding="utf-8",
-        format="{time:YYYY-MM-DD HH:mm:ss} | {level:<8} | {name}:{line} - {message}",
-    )
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
-    with open(log_file, "a", encoding="utf-8") as f:
-        f.write(f"\n{'=' * 60}\n  NEW RUN — {timestamp}\n{'=' * 60}\n\n")
-    logger.info(f"Logging to file: {log_file}")
 
 
 class MainArgs(BaseModel):
@@ -63,8 +36,10 @@ class MainArgs(BaseModel):
 
 
 def main(args: MainArgs) -> None:
-    """
-    Main function to run the ConvFinQA pipeline.
+    """Run the ConvFinQA pipeline end-to-end.
+
+    Orchestrates data ingestion, LLM response generation, LLM-judge evaluation,
+    and output persistence in sequence.
 
     Args:
         args: Validated pipeline arguments.
@@ -109,8 +84,7 @@ def evaluate(
         None, help="Random seed for reproducible sampling. Omit for non-deterministic sampling."
     ),
 ) -> None:
-    """
-    Run the ConvFinQA pipeline with specified parameters.
+    """Run the ConvFinQA pipeline with specified parameters.
 
     Args:
         model_name: The LLM model to use.
@@ -127,7 +101,7 @@ def evaluate(
         seed=seed,
     )
 
-    _configure_logging()
+    configure_logging()
     rich_print("[green]Running ConvFinQA with the following parameters:[/green]")
     rich_print(Pretty(args, expand_all=True))
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,106 @@
+"""
+Core domain types and enumerations for the ConvFinQA pipeline.
+
+This module is the innermost dependency — it imports only from stdlib and pydantic.
+No other app module should be imported here.
+"""
+
+from enum import Enum
+from typing import Self
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ModelName(str, Enum):
+    """Supported model names using OpenRouter provider-prefixed identifiers."""
+
+    GPT_4_1 = "openai/gpt-4.1"
+    GPT_4O = "openai/gpt-4o"
+    GPT_4O_MINI = "openai/gpt-4o-mini"
+    O4_MINI = "openai/o4-mini"
+    GPT_5_4 = "openai/gpt-5.4"
+    GPT_5_4_MINI = "openai/gpt-5.4-mini"
+    GPT_5_5 = "openai/gpt-5.5"
+    CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4.5"
+    CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4.6"
+    GEMINI_3_1_PRO = "google/gemini-3.1-pro-preview"
+    GEMINI_3_1_FLASH_LITE = "google/gemini-3.1-flash-lite-preview"
+
+
+class PromptingStrategy(str, Enum):
+    """Supported prompting strategies."""
+
+    BASIC = "basic"
+    CHAIN_OF_THOUGHT = "chain_of_thought"
+    FEW_SHOT = "few_shot"
+
+
+class FinancialDoc(BaseModel):
+    """Structured representation of a financial document with text and tabular data."""
+
+    pre_text: str = Field(description="Introductory text preceding the table.")
+    post_text: str = Field(description="Explanatory text following the table.")
+    table: dict[str, dict[str, float | str | None]] = Field(description="Tabular data keyed by column then row label.")
+
+    def _format_table(self) -> str:
+        """Render the table dict as a plain-text grid.
+
+        Returns:
+            A tab-separated grid with column headers and row labels.
+        """
+        if not self.table:
+            return ""
+
+        columns = list(self.table.keys())
+        row_labels = list(next(iter(self.table.values())).keys())
+
+        header = "\t".join([""] + columns)
+        rows = ["\t".join([label] + [str(self.table[col].get(label, "")) for col in columns]) for label in row_labels]
+        return "\n".join([header] + rows)
+
+    @property
+    def formatted_doc(self) -> str:
+        """Render the document as a readable string for use in prompts.
+
+        Returns:
+            A formatted string combining pre_text, the table as a grid, and post_text.
+        """
+        return "\n\n".join(
+            [
+                self.pre_text,
+                self._format_table(),
+                self.post_text,
+            ]
+        )
+
+
+class ConvQA(BaseModel):
+    """A single conversational QA entry from the ConvFinQA dataset."""
+
+    id: str = Field(min_length=1, description="Unique identifier for the conversation.")
+    doc: FinancialDoc = Field(description="The structured financial document related to the conversation.")
+    questions: list[str] = Field(min_length=1, description="List of questions in the conversation.")
+    answers: list[str] = Field(min_length=1, description="List of ground-truth answers for the conversation.")
+    llm_answers: list[str] = Field(default_factory=list, description="Structured answers returned by the LLM.")
+    judge_verdicts: list[bool] = Field(
+        default_factory=list, description="Per-answer correctness verdicts from the LLM judge."
+    )
+
+    @property
+    def formatted_questions(self) -> str:
+        """Format questions with delimiter for prompt generation.
+
+        Returns:
+            Questions joined by the {next_question} token used in prompts.
+        """
+        return " {next_question} ".join(self.questions)
+
+    @model_validator(mode="after")
+    def validate_questions_and_answers_same_length(self) -> Self:
+        """Validate that questions and answers lists have the same length."""
+        if len(self.questions) != len(self.answers):
+            raise ValueError(
+                f"Document {self.id}: Questions and answers must have the same length. "
+                f"Got {len(self.questions)} questions and {len(self.answers)} answers."
+            )
+        return self

--- a/app/prompting.py
+++ b/app/prompting.py
@@ -1,61 +1,66 @@
+"""
+Prompt generation strategies for the ConvFinQA pipeline.
+
+Implements the Strategy pattern: each PromptingStrategy enum value maps to a
+concrete PromptStrategy subclass. Adding a new strategy requires only a new
+enum member, a new subclass, and one entry in PromptGenerator._STRATEGY_DICT.
+"""
+
 from abc import ABC, abstractmethod
-from enum import Enum
 
 from loguru import logger
 
-from app.data_parser import ConvQA
-
-
-class PromptingStrategy(str, Enum):
-    """Enum for supported prompting strategies."""
-
-    BASIC = "basic"
-    CHAIN_OF_THOUGHT = "chain_of_thought"
-    FEW_SHOT = "few_shot"
+from app.models import ConvQA, PromptingStrategy
 
 
 class PromptStrategy(ABC):
+    """Abstract base for prompt generation strategies."""
+
     @abstractmethod
     def generate_prompt(self, doc: str, questions: str) -> str:
-        """
-        Generate a prompt based on the document and questions.
+        """Generate a prompt from the formatted document and questions.
+
         Args:
-            doc (str): The document containing relevant information.
-            questions (str): The formatted questions to be answered.
+            doc: The rendered financial document string.
+            questions: The formatted questions string with {next_question} delimiters.
+
         Returns:
-            str: The generated prompt string.
+            The complete prompt string to send to the LLM.
         """
-        pass
 
 
 class BasicPromptStrategy(PromptStrategy):
+    """Minimal prompt containing only the document and questions."""
+
     def generate_prompt(self, doc: str, questions: str) -> str:
-        """
-        Construct a minimal prompt containing only the document and questions.
+        """Construct a minimal prompt containing only the document and questions.
 
         The system prompt already provides all task framing and tool-use instructions.
 
         Args:
-            doc (str): The financial document with 'pre_text', 'post_text', and 'table'.
-            questions (str): A formatted string with {next_question} as delimiters.
+            doc: The financial document with 'pre_text', 'post_text', and 'table'.
+            questions: A formatted string with {next_question} as delimiters.
 
         Returns:
-            str: The generated prompt string.
+            The generated prompt string.
         """
         return f"Document:\n{doc}\n\nQuestions:\n{questions}"
 
 
 class ChainOfThoughtPromptStrategy(PromptStrategy):
+    """Prompt that prepends a step-by-step reasoning instruction."""
+
     def generate_prompt(self, doc: str, questions: str) -> str:
-        """
-        Construct a prompt that prepends a step-by-step reasoning instruction.
+        """Construct a prompt that prepends a step-by-step reasoning instruction.
 
         The system prompt handles task framing; this adds only the CoT nudge.
+
         Args:
-            doc (str): The financial document with 'pre_text', 'post_text', and 'table'.
-            questions (str): A formatted string with {next_question} as delimiters.
+            doc: The financial document with 'pre_text', 'post_text', and 'table'.
+            questions: A formatted string with {next_question} as delimiters.
+
         Returns:
-            str: The generated prompt string.
+            The generated prompt string.
         """
         return (
             "Think through each question step-by-step before arriving at a final numeric answer.\n\n"
@@ -65,16 +70,17 @@ class ChainOfThoughtPromptStrategy(PromptStrategy):
 
 
 class FewShotPromptStrategy(PromptStrategy):
+    """Prompt with example Q&A pairs drawn from the dataset."""
+
     def generate_prompt(self, doc: str, questions: str) -> str:
-        """
-        Construct a few-shot prompt with example Q&A pairs drawn from the dataset.
+        """Construct a few-shot prompt with example Q&A pairs drawn from the dataset.
 
         Args:
-            doc (str): The financial document with 'pre_text', 'post_text', and 'table'.
-            questions (str): A formatted string with {next_question} as delimiters.
+            doc: The financial document with 'pre_text', 'post_text', and 'table'.
+            questions: A formatted string with {next_question} as delimiters.
 
         Returns:
-            str: The generated prompt string.
+            The generated prompt string.
         """
         return (
             "Here are three example Q&A pairs:\n\n"
@@ -102,6 +108,8 @@ class FewShotPromptStrategy(PromptStrategy):
 
 
 class PromptGenerator:
+    """Selects a prompting strategy and generates prompts from ConvQA objects."""
+
     _STRATEGY_DICT: dict[PromptingStrategy, type[PromptStrategy]] = {
         PromptingStrategy.BASIC: BasicPromptStrategy,
         PromptingStrategy.CHAIN_OF_THOUGHT: ChainOfThoughtPromptStrategy,
@@ -109,8 +117,7 @@ class PromptGenerator:
     }
 
     def __init__(self, strategy: PromptingStrategy) -> None:
-        """
-        Initialise the PromptGenerator with a specific strategy.
+        """Initialise the PromptGenerator with a specific strategy.
 
         Args:
             strategy: The prompting strategy to use.
@@ -119,16 +126,14 @@ class PromptGenerator:
         logger.info(f"Using prompt strategy: {strategy.value}")
 
     def generate_prompt(self, conversation: ConvQA) -> str:
-        """
-        Generate a prompt using the specified strategy, given a document and questions.
+        """Generate a prompt from a conversation using the configured strategy.
 
         Args:
-            conversation (ConvQA): The conversation object containing document and questions.
+            conversation: The conversation object containing document and questions.
 
         Returns:
-            str: The generated prompt string.
+            The generated prompt string.
         """
         doc = conversation.doc.formatted_doc
         questions = conversation.formatted_questions
-
         return self._strategy.generate_prompt(doc, questions)

--- a/app/results_writer.py
+++ b/app/results_writer.py
@@ -7,9 +7,7 @@ import os
 
 from loguru import logger
 
-from app.agent import ModelName
-from app.data_parser import ConvQA
-from app.prompting import PromptingStrategy
+from app.models import ConvQA, ModelName, PromptingStrategy
 
 _OUTPUT_ROOT = "/code/outputs"
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,8 @@ from pydantic_ai import Agent
 from pydantic_ai.models.openrouter import OpenRouterModel
 from pydantic_ai.models.test import TestModel
 
-from app.agent import LlmAnswers, ModelName, build_agent, get_response
+from app.agent import LlmAnswers, build_agent, get_response
+from app.models import ModelName
 from app.settings import Settings
 
 _EXPECTED_TOOLS = {"add", "subtract", "multiply", "divide", "percentage_change", "greater", "exp"}

--- a/tests/test_data_parser.py
+++ b/tests/test_data_parser.py
@@ -4,7 +4,8 @@ from collections.abc import Iterator
 
 import pytest
 
-from app.data_parser import ConvFinQaDataParser, ConvQA, FinancialDoc
+from app.data_parser import ConvFinQaDataParser
+from app.models import ConvQA, FinancialDoc
 
 
 @pytest.fixture

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 import pytest
 from pydantic_ai.models.test import TestModel
 
-from app.data_parser import ConvQA, FinancialDoc
 from app.evaluator import ConversationsEvaluator
 from app.judge import build_judge_agent
+from app.models import ConvQA, FinancialDoc
 from app.settings import Settings
 
 _SAMPLE_DOC = FinancialDoc(

--- a/tests/test_generate_responses.py
+++ b/tests/test_generate_responses.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agent import build_agent
 from app.generate_responses import GetAllLlmResponses
 from app.models import ConvQA, FinancialDoc, ModelName, PromptingStrategy
 from app.settings import Settings
@@ -55,16 +56,17 @@ def dummy_convqa() -> ConvQA:
 @pytest.fixture
 def generator() -> GetAllLlmResponses:
     """
-    GIVEN a mocked data parser and agent,
+    GIVEN a mocked data parser and a pre-built test agent,
     WHEN creating a GetAllLlmResponses instance,
     THEN return an instance with a minimal in-memory conversation list.
     """
+    agent = build_agent(model_name=ModelName.GPT_4_1, max_retries=3)
     with patch("app.generate_responses.ConvFinQaDataParser") as mock_parser_cls:
         mock_parser = MagicMock()
         mock_parser.parse_all_conversations.return_value = []
         mock_parser_cls.return_value = mock_parser
         instance = GetAllLlmResponses(
-            model_name=ModelName.GPT_4_1,
+            agent=agent,
             prompting_strategy=PromptingStrategy.CHAIN_OF_THOUGHT,
             load_train_data=False,
             sample_size=0,

--- a/tests/test_generate_responses.py
+++ b/tests/test_generate_responses.py
@@ -8,10 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic_ai.models.test import TestModel
 
-from app.agent import ModelName
-from app.data_parser import ConvQA, FinancialDoc
 from app.generate_responses import GetAllLlmResponses
-from app.prompting import PromptingStrategy
+from app.models import ConvQA, FinancialDoc, ModelName, PromptingStrategy
 from app.settings import Settings
 
 _SAMPLE_DOC = FinancialDoc(

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -81,7 +81,7 @@ class TestBuildJudgeAgent:
         WHEN build_judge_agent is called,
         THEN the agent's model is OpenRouterModel configured with the Flash Lite model.
         """
-        from app.agent import ModelName
+        from app.models import ModelName
 
         agent = build_judge_agent()
 

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.data_parser import ConvQA, FinancialDoc
-from app.prompting import PromptGenerator, PromptingStrategy
+from app.models import ConvQA, FinancialDoc, PromptingStrategy
+from app.prompting import PromptGenerator
 
 _CONVERSATION = ConvQA(
     id="conv1",

--- a/tests/test_results_writer.py
+++ b/tests/test_results_writer.py
@@ -7,9 +7,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from app.agent import ModelName
-from app.data_parser import ConvQA, FinancialDoc
-from app.prompting import PromptingStrategy
+from app.models import ConvQA, FinancialDoc, ModelName, PromptingStrategy
 from app.results_writer import ResultsWriter
 
 _SAMPLE_DOC = FinancialDoc(


### PR DESCRIPTION
## Summary

Structural refactor that introduces two new modules — `app/models.py` and `app/log.py` — as dedicated homes for shared domain types and logging configuration. All existing functionality is preserved; no user-visible behaviour changes.

## Why

Several cross-module coupling problems existed before this PR:

- `judge.py` imported from `agent.py` solely to borrow `ModelName`, coupling two independent infrastructure modules.
- `results_writer.py` imported from three unrelated modules (`agent`, `data_parser`, `prompting`) just to obtain three enum/type definitions.
- Every consumer of `ConvQA` and `FinancialDoc` was coupled to `data_parser.py`, a file I/O module, even when they had no interest in parsing.
- Logging setup lived in `main.py`, mixing CLI wiring with infrastructure concerns.

This PR eliminates those coupling problems by giving shared types and logging a proper home, without over-engineering (flat layout preserved, no sub-packages introduced).

## Implementation notes

- **`app/models.py`** — new single source of truth for `ConvQA`, `FinancialDoc`, `ModelName`, and `PromptingStrategy`. Imports only stdlib and pydantic; no other app module is imported here, making it the innermost dependency in the graph.
- **`app/log.py`** — extracted `configure_logging()` and the `LOG_FILE` constant out of `main.py` into a dedicated module with a single public function.
- **`app/agent.py`** — removed the `ModelName` enum (moved to `models.py`) and eliminated a duplicate `_INITIAL_RETRY_DELAY_SECONDS` constant that was defined twice (previously at lines 20 and 122).
- **`app/judge.py`** — changed `from app.agent import ModelName` → `from app.models import ModelName`.
- **`app/prompting.py`** — removed `PromptingStrategy` enum definition; imports `ConvQA` and `PromptingStrategy` from `models.py`.
- **`app/data_parser.py`** — removed `ConvQA` and `FinancialDoc` class definitions; parser now imports types from `models.py` (correct direction: infra depending on domain types).
- **`app/results_writer.py`** — three separate type imports collapsed into a single `from app.models import ConvQA, ModelName, PromptingStrategy`.
- **`app/evaluator.py`** and **`app/generate_responses.py`** — import paths updated to `app.models`.
- **`app/main.py`** — logging code removed; now imports `configure_logging` from `app.log` and enums from `app.models`, leaving it with a single responsibility: CLI wiring.
- **7 test files** — import paths updated to `app.models`; no logic changes.

## Testing

- All 66 tests pass (`pytest`).
- `ruff` clean, `pyrefly` clean.
- Successful end-to-end pipeline run completed (Gemini Flash Lite, basic prompting, 50 samples → 62.40% accuracy), confirming no regressions.

## Screenshots (optional)

N/A

## Checklist

- [x] Performed self-review
- [x] Manually tested end-to-end
- [ ] Written tests for any new functionality
- [ ] Updated the README if appropriate
- [ ] Updated `sample.env` if env vars changed
- [ ] Updated the README env var table if env vars changed
- [x] Conventional commit message used (`feat:`, `fix:`, `chore:`, etc.)
